### PR TITLE
插件添加babelInclude钩子

### DIFF
--- a/__tests__/fetch/node.award.spec.ts
+++ b/__tests__/fetch/node.award.spec.ts
@@ -119,7 +119,7 @@ describe('测试award-fetch  node', () => {
 
   it('测试未配置 fetchConfig的domainMap', async () => {
     const root = require
-      .resolve('@/fixtures/basic/examples/b/index.tsx')
+      .resolve('@/fixtures/basic/examples/g/index.tsx')
       .replace(isWin ? /\\index\.tsx$/ : /\/index\.tsx$/, '');
     process.chdir(root);
     const fetch = require('award-fetch').default;

--- a/docs/plugin/node.md
+++ b/docs/plugin/node.md
@@ -193,6 +193,40 @@ award项目执行`award build`构建命令之前
 | run_env | 构建的环境类型      | 'node' 、 'web_ssr' 、 'web_spa' |
 | config  | 当前项目的award配置 | object                           |
 
+### babelInclude
+
+在`web`编译阶段，判断babel插件是否需要处理该文件，类似webpack include用法，该钩子只支持同步
+
+> 需要注意：仅`web`编译可以使用，包括开发环境和编译出生产环境的静态资源
+>
+> 只接受一个参数`filePath`，表示当前文件路径；如果需要处理成功，需要给出返回值，类型为`boolean`
+
+**award内部默认处理规则**
+
+- 不忽略 node_modules\/award
+- 忽略 node_modules `该钩子会在这个阶段执行`
+- 其余都不忽略
+
+**示例**
+ ```js
+ import Plugin from 'award-plugin';
+ 
+ export default class extends Plugin.Node{
+   apply(){
+     this.build(hooks=>{
+       hooks.babelInclude(function(filePath){
+         // 当award内部的默认规则要求babel-loader忽略对该文件的处理后.....
+         // 紧接着立刻触发该钩子
+         // 接着你就可以通过正则匹配决定是否处理该文件路径
+         // 如果不返回，或者返回false，那么babel-loader就不再处理该文件了
+         // 只有返回true才会处理该文件
+         return ...  
+ 	     })
+     })
+   }
+ }
+ ```
+
 ### source
 
 处理编译后的静态资源

--- a/fixtures/basic/examples/g/award.config.js
+++ b/fixtures/basic/examples/g/award.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   fetch: {
-    domainMap: {}
+    domainMap: null
   }
 };

--- a/fixtures/basic/examples/g/index.tsx
+++ b/fixtures/basic/examples/g/index.tsx
@@ -1,0 +1,4 @@
+import * as React from 'react';
+import { start } from 'award';
+
+start(<h1>hello world</h1>);

--- a/fixtures/basic/examples/g/package.json
+++ b/fixtures/basic/examples/g/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "fixtures",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/fixtures/basic/examples/g/tsconfig.json
+++ b/fixtures/basic/examples/g/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "module": "esnext",
+    "target": "esnext",
+    "jsx": "preserve",
+    "experimentalDecorators": true,
+    "moduleResolution": "node"
+  },
+  "include": ["."]
+}

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.0.22",
+  "version": "0.0.23-alpha.3",
   "versions": {
-    "alpha": "0.0.21-alpha.4"
+    "alpha": "0.0.23-alpha.3"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/packages/award-plugin/src/client/client.ts
+++ b/packages/award-plugin/src/client/client.ts
@@ -16,9 +16,10 @@ let _award_plugins_: any = {};
 
 const asyncStart = async (hookName: string, params: any) => {
   const nameL = storeApis[hookName].length;
+  let content = null;
+  let result = true;
   if (nameL) {
     let i = 0;
-    let content = null;
     while (i < nameL) {
       const { fn, name } = storeApis[hookName][i];
       try {
@@ -28,6 +29,10 @@ const asyncStart = async (hookName: string, params: any) => {
           },
           params
         );
+        if (typeof content === 'boolean' && !content) {
+          // 一旦其中某个插件执行结果是false，那么针对布尔类型的返回值都将是false
+          result = false;
+        }
         i++;
       } catch (error) {
         throw new Error(
@@ -36,13 +41,18 @@ const asyncStart = async (hookName: string, params: any) => {
       }
     }
   }
+  if (!result) {
+    return false;
+  }
+  return content;
 };
 
 const syncStart = (hookName: string, params: any) => {
   const nameL = storeApis[hookName].length;
+  let content = null;
+  let result = true;
   if (nameL) {
     let i = 0;
-    let content = null;
     while (i < nameL) {
       const { fn, name } = storeApis[hookName][i];
       try {
@@ -52,6 +62,10 @@ const syncStart = (hookName: string, params: any) => {
           },
           params
         );
+        if (typeof content === 'boolean' && !content) {
+          // 一旦其中某个插件执行结果是false，那么针对布尔类型的返回值都将是false
+          result = false;
+        }
         i++;
       } catch (error) {
         throw new Error(
@@ -60,6 +74,10 @@ const syncStart = (hookName: string, params: any) => {
       }
     }
   }
+  if (!result) {
+    return false;
+  }
+  return content;
 };
 
 export const register = (plugins: Array<any>) => {
@@ -104,13 +122,13 @@ export default (names: Array<any>) => {
     if (fnType === 'sync') {
       // 同步任务
       hooks[fnName] = (params?: any) => {
-        syncStart(fnName, params);
+        return syncStart(fnName, params);
       };
     }
     if (fnType === 'async') {
       // 异步任务
       hooks[fnName] = async (params?: any) => {
-        await asyncStart(fnName, params);
+        return await asyncStart(fnName, params);
       };
     }
   });

--- a/packages/award-plugin/src/node/index.ts
+++ b/packages/award-plugin/src/node/index.ts
@@ -32,7 +32,7 @@ const serverName = [
 
 const renderName = ['beforeRender', 'render', 'document', 'afterRender'];
 
-const buildName = ['beforeBuild', 'source', 'afterBuild'];
+const buildName = ['beforeBuild', 'source', 'afterBuild', 'sync babelInclude'];
 
 const configName = ['webpackConfig', 'sync babelConfig'];
 
@@ -86,6 +86,9 @@ const hooks: {
 
   /** source */
   source: (params: Isource) => Promise<any>;
+
+  /** 处理babel插件include，该钩子只支持同步 */
+  babelInclude: (filePath: string) => any;
 } = node(names);
 
 export default {

--- a/packages/award-plugin/src/node/node.ts
+++ b/packages/award-plugin/src/node/node.ts
@@ -10,9 +10,10 @@ let currentName: any = null;
 
 const asyncStart = async (hookName: string, params: any) => {
   const nameL = storeApis[hookName].length;
+  let content = null;
+  let result = true;
   if (nameL) {
     let i = 0;
-    let content = null;
     while (i < nameL) {
       const { fn, name } = storeApis[hookName][i];
       try {
@@ -22,6 +23,10 @@ const asyncStart = async (hookName: string, params: any) => {
           },
           params
         );
+        if (typeof content === 'boolean' && !content) {
+          // 一旦其中某个插件执行结果是false，那么针对布尔类型的返回值都将是false
+          result = false;
+        }
         i++;
       } catch (error) {
         throw new Error(
@@ -30,13 +35,18 @@ const asyncStart = async (hookName: string, params: any) => {
       }
     }
   }
+  if (!result) {
+    return false;
+  }
+  return content;
 };
 
 const syncStart = (hookName: string, params: any) => {
   const nameL = storeApis[hookName].length;
+  let content = null;
+  let result = true;
   if (nameL) {
     let i = 0;
-    let content = null;
     while (i < nameL) {
       const { fn, name } = storeApis[hookName][i];
       try {
@@ -46,6 +56,10 @@ const syncStart = (hookName: string, params: any) => {
           },
           params
         );
+        if (typeof content === 'boolean' && !content) {
+          // 一旦其中某个插件执行结果是false，那么针对布尔类型的返回值都将是false
+          result = false;
+        }
         i++;
       } catch (error) {
         throw new Error(
@@ -54,6 +68,10 @@ const syncStart = (hookName: string, params: any) => {
       }
     }
   }
+  if (!result) {
+    return false;
+  }
+  return content;
 };
 
 export const register = (plugins: Array<any>) => {
@@ -104,13 +122,13 @@ export default (names: Array<any>) => {
     if (fnType === 'sync') {
       // 同步任务
       hooks[fnName] = (params?: any) => {
-        syncStart(fnName, params);
+        return syncStart(fnName, params);
       };
     }
     if (fnType === 'async') {
       // 异步任务
       hooks[fnName] = async (params?: any) => {
-        await asyncStart(fnName, params);
+        return await asyncStart(fnName, params);
       };
     }
   });

--- a/packages/award-plugin/types/node.d.ts
+++ b/packages/award-plugin/types/node.d.ts
@@ -151,6 +151,8 @@ export interface Isource {
 }
 export type source = (callback: (params: Isource) => void) => void;
 
+/** 判断babel插件是否需要处理该文件，类似webpack include用法，该钩子只支持同步 */
+export type babelInclude = (callback: (filePath: string) => any) => void;
 export interface NodeHooks {
   modifyContextAward: modifyContextAward;
   modifyInitialPropsCtx: modifyInitialPropsCtx;
@@ -169,4 +171,5 @@ export interface NodeHooks {
   babelConfig: babelConfig;
   document: document;
   source: source;
+  babelInclude: babelInclude;
 }

--- a/packages/award-scripts/src/tools/build/utils/include.ts
+++ b/packages/award-scripts/src/tools/build/utils/include.ts
@@ -1,4 +1,5 @@
 import * as os from 'os';
+import nodePlugin from 'award-plugin/node';
 
 export default (filePath: string) => {
   let regNodeModules = /\/node_modules\//;
@@ -9,13 +10,14 @@ export default (filePath: string) => {
     regAward = /\\node_modules\\award/;
     regNodeModules = /\\node_modules\\/;
   }
+
   // 不忽略 node_modules\/award
   if (regAward.test(filePath)) {
     return true;
   }
   // 忽略  node_modules
   if (regNodeModules.test(filePath)) {
-    return false;
+    return nodePlugin.hooks.babelInclude(filePath) ? true : false;
   }
   // 其余都不忽略
   return true;


### PR DESCRIPTION
**award内部默认处理规则**

- 不忽略 node_modules\/award
- 忽略 node_modules `该钩子会在这个阶段执行`
- 其余都不忽略

**示例**
 ```js
 import Plugin from 'award-plugin';
 
 export default class extends Plugin.Node{
   apply(){
     this.build(hooks=>{
       hooks.babelInclude(function(filePath){
         // 当award内部的默认规则要求babel-loader忽略对该文件的处理后.....
         // 紧接着立刻触发该钩子
         // 接着你就可以通过正则匹配决定是否处理该文件路径
         // 如果不返回，或者返回false，那么babel-loader就不再处理该文件了
         // 只有返回true才会处理该文件
         return ...  
 	     })
     })
   }
 }
 ```

>[点击查看文档](http://openact.ximalaya.com/award/docs/plugin/node/#babelinclude)