### PR TITLE
调整interceptors逻辑

### DIFF
--- a/__tests__/fetch/web.spec.ts
+++ b/__tests__/fetch/web.spec.ts
@@ -44,8 +44,10 @@ describe('测试award-fetch web', () => {
     });
 
     fetch.interceptors.response.use((res: any) => {
-      res = res + ' world';
-      return res;
+      return new Promise(async resolve => {
+        const data = await res.text();
+        resolve(data + ' world');
+      });
     });
 
     const info = jest.fn();

--- a/common.d.ts
+++ b/common.d.ts
@@ -21,6 +21,7 @@ declare namespace NodeJS {
 
   export interface Global {
     inServer: boolean;
+    ServerHmr: boolean;
     AppRegistry: Function;
     __AWARD__PLUGINS__: {
       [name: string]: {

--- a/docs/basic/server.md
+++ b/docs/basic/server.md
@@ -168,10 +168,11 @@ app.listen(1234, (listen, url, open) => {
 ```js
 ...
 
-app.catch((errLogs)=>{
+app.catch((errLogs, ctx) => {
   // 处理errLogs是否落盘逻辑，对errLogs的字段进行判断处理
   // 根据业务需求，确认是否需要需要返回errLogs，将errLogs落盘到日志
   // 如果不需要落盘日志，可以不返回，或者返回null
+  // ctx 表示当前发生错误的请求的上下文
   return errLogs
 })
 

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -6,6 +6,12 @@ import About from './about';
 import './common.scss!';
 import './app.scss';
 
+fetch.interceptors.response.use((response, log) => {
+  log.error('发生错误了', 'interceptors response');
+  console.error(1234, response.status);
+  return response.json();
+});
+
 function app(props) {
   const [info, setInfo] = useState({
     name: 'Award'
@@ -50,7 +56,12 @@ function app(props) {
 
 app.getInitialProps = ctx => {
   const result = [
-    fetch('/api/list').then(data => {
+    fetch('/api/list', {
+      transformResponse: response => {
+        console.log(321, response);
+        return response;
+      }
+    }).then(data => {
       ctx.setAward({
         num: data.num
       });

--- a/examples/basic/server.js
+++ b/examples/basic/server.js
@@ -3,8 +3,9 @@ const Server = require('award/server');
 // 实例化，获取app，构造函数接收对象
 const app = new Server();
 
-app.use(async ctx => {
-  ctx.body = 123;
+app.catch((errLogs, ctx) => {
+  console.info('ctx', ctx.path);
+  return errLogs;
 });
 
 // 监听端口

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.20.0-alpha.0",
+  "version": "0.20.0-alpha.1",
   "versions": {
-    "alpha": "0.20.0-alpha.0"
+    "alpha": "0.20.0-alpha.1"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.19.0",
+  "version": "0.20.0-alpha.0",
   "versions": {
-    "alpha": "0.19.0-alpha.2"
+    "alpha": "0.20.0-alpha.0"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.20.0-alpha.1",
+  "version": "0.20.0-alpha.2",
   "versions": {
-    "alpha": "0.20.0-alpha.1"
+    "alpha": "0.20.0-alpha.2"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/packages/award-fetch/src/env/file/index.ts
+++ b/packages/award-fetch/src/env/file/index.ts
@@ -1,8 +1,9 @@
-module.exports = (options: object) => {
+module.exports = (options: object, isInterceptorsResponse: boolean) => {
   return new Promise((resolve, reject) => {
     (function doSocket(win) {
       const _ws = new WebSocket((win as any).AwardWebSocket.url);
       _ws.onopen = () => {
+        (options as any).__file__isInterceptorsResponse = isInterceptorsResponse;
         _ws.send(JSON.stringify(options));
         _ws.onmessage = evt => {
           _ws.close();

--- a/packages/award-fetch/src/env/server/index.ts
+++ b/packages/award-fetch/src/env/server/index.ts
@@ -1,4 +1,4 @@
 import ServerFetch from './server';
-module.exports = (option: any) => {
-  return ServerFetch(option);
+module.exports = (option: any, isInterceptorsResponse: boolean) => {
+  return ServerFetch(option, isInterceptorsResponse);
 };

--- a/packages/award-fetch/src/env/server/server.ts
+++ b/packages/award-fetch/src/env/server/server.ts
@@ -34,9 +34,11 @@ class HttpClient {
     try {
       const uri = await this.getUri(url);
       if (!/^http(s)?:/.test(uri)) {
-        throw new Error(
-          `请求地址[${url}]匹配的domain必须设置http协议，当前node请求的完整url为${uri}`
-        );
+        throw {
+          status: 500,
+          message: `请求地址[${url}]匹配的domain必须设置http协议，当前node请求的完整url为${uri}`,
+          fetch: true
+        };
       }
       const _time1 = Number(new Date());
       console.info(`[server-fetch-start]:${uri}`);
@@ -51,7 +53,7 @@ class HttpClient {
         ).then(response => {
           if (response.status < 200 || response.status > 350) {
             // 需要重试
-            throw new Error(`${response.url}: ${response.statusText}`);
+            throw { status: 500, message: `${response.url}: ${response.statusText}`, fetch: true };
           }
           return response;
         });

--- a/packages/award-fetch/src/env/server/url.ts
+++ b/packages/award-fetch/src/env/server/url.ts
@@ -11,12 +11,20 @@ export function getUrlPrefix(url: string) {
   }
   /**  //a.com/b/c **/
   if (/^\/\//.test(url)) {
-    throw new Error('Node端发起http请求时，请指定协议');
+    throw {
+      status: 500,
+      message: 'Node端发起http请求时，请指定协议',
+      fetch: true
+    };
   }
   const { fetch: fetchConfig }: any = getAwardConfig();
   const { domainMap } = fetchConfig;
   if (!domainMap) {
-    throw new Error('Node端发起http请求时，请确保配置了domainMap');
+    throw {
+      status: 500,
+      message: 'Node端发起http请求时，请确保配置了domainMap',
+      fetch: true
+    };
   }
   let domainPrefix = null;
   Object.keys(domainMap).forEach(item => {
@@ -29,7 +37,11 @@ export function getUrlPrefix(url: string) {
   if (domainPrefix) {
     return domainPrefix;
   }
-  throw new Error(`Node端发起请求[${url}]，没有找到对应的domainMap`);
+  throw {
+    status: 500,
+    message: `Node端发起请求[${url}]，没有找到对应的domainMap`,
+    fetch: true
+  };
 }
 
 /**

--- a/packages/award-fetch/src/env/thrift/index.ts
+++ b/packages/award-fetch/src/env/thrift/index.ts
@@ -1,6 +1,6 @@
 import thrift from './thrift';
 import { IOptthrift } from '../../interfaces/fetchOptions';
 
-module.exports = (options: IOptthrift, thriftUtils: any) => {
-  return thrift(options, thriftUtils);
+module.exports = (options: IOptthrift, thriftUtils: any, isInterceptorsResponse: boolean) => {
+  return thrift(options, thriftUtils, isInterceptorsResponse);
 };

--- a/packages/award-fetch/src/env/thrift/thrift.ts
+++ b/packages/award-fetch/src/env/thrift/thrift.ts
@@ -77,7 +77,11 @@ export default (
       getThriftServer(API_APIGATEWAY_PATH).then(addr => {
         try {
           if (!addr) {
-            throw new Error('no thrift host find');
+            throw {
+              status: 500,
+              message: 'no thrift host find',
+              fetch: true
+            };
           }
 
           const [host, port] = addr.split(':');

--- a/packages/award-fetch/src/env/thrift/thrift.ts
+++ b/packages/award-fetch/src/env/thrift/thrift.ts
@@ -48,7 +48,8 @@ export default (
   options: IOptthrift,
   thriftUtils: {
     getClients: Function;
-  }
+  },
+  isInterceptorsResponse: boolean
 ): Promise<any> => {
   const { fetch: fetchConfig = {} }: any = getAwardConfig();
 
@@ -106,7 +107,7 @@ export default (
           const callback = (err: Error, re: any) => {
             if (err) {
               log.error(err, 'fetch-to-thrift-err');
-              fetch(options)
+              fetch(options, isInterceptorsResponse)
                 .then(resolve)
                 .catch(reject);
               thriftClients[thriftKey] = null;
@@ -123,7 +124,7 @@ export default (
         } catch (e) {
           log.error(e, 'thriftPool-connnect-error');
           // thrift连接失败 换http请求
-          fetch(options)
+          fetch(options, isInterceptorsResponse)
             .then(resolve)
             .catch(reject);
           thriftClients[thriftKey] = null;
@@ -131,5 +132,5 @@ export default (
       });
     });
   }
-  return fetch(options);
+  return fetch(options, isInterceptorsResponse);
 };

--- a/packages/award-fetch/src/env/web/index.ts
+++ b/packages/award-fetch/src/env/web/index.ts
@@ -2,7 +2,7 @@ import { loadParams } from 'award-utils';
 import { IOpt1 } from '../../interfaces/fetchOptions';
 import fetch from '../../utils/fetch';
 
-module.exports = (options: IOpt1) => {
+module.exports = (options: IOpt1, isInterceptorsResponse: boolean) => {
   // url
   if (!/^http(s)?:|^\/\//.test(options.url) && (options as any).basename) {
     const { basename } = loadParams.get();
@@ -10,5 +10,5 @@ module.exports = (options: IOpt1) => {
       options.url = basename + (/^\//.test(options.url) ? '' : '/') + options.url;
     }
   }
-  return fetch(options);
+  return fetch(options, isInterceptorsResponse);
 };

--- a/packages/award-fetch/src/index.ts
+++ b/packages/award-fetch/src/index.ts
@@ -1,17 +1,34 @@
 import isString = require('lodash/isString');
 import reduce = require('lodash/reduce');
 import { IOpt1, IOptUserBase } from './interfaces/fetchOptions';
-import { set as _setLog } from './utils/log';
+import log, { set as _setLog } from './utils/log';
 import * as thriftUtils from './utils/thrift'; // 防止开发环境模块重新载入
 import { COMMONERROR, ABORTERROR } from './utils/constant';
 
 // fetch 拦截器
-const _interceptors: {
+let _interceptors: {
   request: Function[];
   response: Function[];
 } = {
   request: [],
   response: []
+};
+
+export interface Log {
+  error: (err: Error | string, name: string) => void;
+}
+
+const interceptors = {
+  request: {
+    use: (func: (response: Request, log: Log) => Request) => {
+      _interceptors.request.push(func);
+    }
+  },
+  response: {
+    use: (func: (response: Response, log: Log) => Response) => {
+      _interceptors.response.push(func);
+    }
+  }
 };
 
 /**
@@ -20,12 +37,48 @@ const _interceptors: {
  * import fetch from 'award-fetch'
  *
  * fetch({
- *   url:"/api",
- *   // 直接处理响应返回的内容
- *   transformResponse:()=>{
+ *   url: "/api",
+ *   // 劫持单个请求的的response处理
+ *   transformResponse: () => {
  *
  *   }
  * })
+ * ```
+ *
+ * ## 请求劫持处理
+ *
+ * ```
+ * // request 表示请求参数
+ * // log是函数，可以在服务器输出错误 log.error
+ * fetch.interceptors.request.use((request, log) => {
+ *  console.log(request);
+ *  return request
+ * })
+ *
+ * // 响应劫持处理
+ * // response 表示请求参数
+ * // log是函数，可以在服务器输出错误 log.error
+ * fetch.interceptors.response.use((response, log) => {
+ *  console.log(response);
+ *  return response.json();
+ * })
+ * ```
+ *
+ * ## 取消fetch，目前仅支持xhr取消
+ * ```
+ *
+ * const source = fetch.source();
+ * // 发起上传请求
+ * fetch({
+ *  url: '/api/upload',
+ *  method: 'POST',
+ *  xhr: true,
+ *  data: fileInfo,
+ *  cancelToken: source.token
+ * });
+ *
+ * // 终止上传
+ * source.cancel();
  * ```
  */
 async function awardFetch(options: string | IOpt1, otherOptions?: IOptUserBase): Promise<any> {
@@ -45,7 +98,7 @@ async function awardFetch(options: string | IOpt1, otherOptions?: IOptUserBase):
   options = reduce(
     _interceptors.request,
     (req, interceptor): IOpt1 => {
-      const result = interceptor(req);
+      const result = interceptor(req, log);
       if (result) {
         return result;
       } else {
@@ -59,55 +112,52 @@ async function awardFetch(options: string | IOpt1, otherOptions?: IOptUserBase):
 
   (options as any).basename = awardFetch.basename;
 
+  const isInterceptorsResponse = Boolean(_interceptors.response.length);
+
   // 环境判断
   if (process.env.RUN_ENV === 'node') {
     const { thrift } = options;
     if (thrift) {
-      response = require('./env/thrift')(options, thriftUtils);
+      response = require('./env/thrift')(options, thriftUtils, isInterceptorsResponse);
     } else {
-      response = require('./env/server')(options);
+      response = require('./env/server')(options, isInterceptorsResponse);
     }
   } else if (process.env.WEB_TYPE === 'WEB_SPA') {
     // 单页应用开发环境
     if (Number(process.env.Browser) === 1) {
       // 这里走websocket
-      response = require('./env/file')(options);
+      response = require('./env/file')(options, isInterceptorsResponse);
     } else {
       // 这里是web端
-      response = require('./env/web')(options);
+      response = require('./env/web')(options, isInterceptorsResponse);
     }
   } else {
     // 这里是在线的web端
-    response = require('./env/web')(options);
+    response = require('./env/web')(options, isInterceptorsResponse);
   }
-  return response.then((data: any) => {
-    return reduce(
-      _interceptors.response,
-      (res, interceptor) => {
-        const result = interceptor(res);
-        if (result) {
-          return result;
-        } else {
-          return res;
-        }
-      },
-      data
-    );
-  });
+  return response
+    .then((data: any) => {
+      return reduce(
+        _interceptors.response,
+        (res, interceptor) => {
+          const result = interceptor(res, log);
+          if (result) {
+            return result;
+          } else {
+            return res;
+          }
+        },
+        data
+      );
+    })
+    .then((data: any) => {
+      if (isInterceptorsResponse && typeof (options as any).transformResponse === 'function') {
+        return (options as any).transformResponse(data);
+      } else {
+        return data;
+      }
+    });
 }
-
-const interceptors = {
-  request: {
-    use: (func: Function) => {
-      _interceptors.request.push(func);
-    }
-  },
-  response: {
-    use: (func: Function) => {
-      _interceptors.response.push(func);
-    }
-  }
-};
 
 function all(fetches: any) {
   return fetches;
@@ -134,61 +184,8 @@ const setLog = (customLog: { error: Function }) => {
 
 export { interceptors, all, source, setLog };
 
-/**
- * ```
- * import fetch from 'award-fetch'
- *
- * // 请求劫持处理
- * fetch.interceptors.request.use((response) => {
- *  console.log(request);
- *  return request
- * })
- *
- * // 响应劫持处理
- * fetch.interceptors.response.use((response) => {
- *  console.log(response);
- *  return response.json();
- * })
- * ```
- */
 awardFetch.interceptors = interceptors;
-
-/**
- *
- * 同时处理多个fetch
- * ```
- * {
- *  a: fetchFunc1,
- *  b: fetchFunc2,
- * }
- * ===> Promise
- * {
- *  a: fetchRes1,
- *  b: fetchRes2,
- * }
- * ```
- */
 awardFetch.all = all;
-
-/**
- * 取消fetch，目前仅支持xhr取消
- * ```
- * import fetch from 'award-fetch';
- *
- * const source = fetch.source();
- * // 发起上传请求
- * fetch({
- *  url: '/api/upload',
- *  method: 'POST',
- *  xhr: true,
- *  data: fileInfo,
- *  cancelToken: source.token
- * });
- *
- * // 终止上传
- * source.cancel();
- * ```
- */
 awardFetch.source = source;
 awardFetch.setLog = setLog;
 
@@ -198,5 +195,14 @@ awardFetch.ABORT_ERROR = ABORTERROR;
 
 /** 指定是否需要启用当前basename */
 awardFetch.basename = false;
+
+awardFetch.clean = () => {
+  if (process.env.NODE_ENV === 'development') {
+    if (global.ServerHmr) {
+      _interceptors.request = [];
+      _interceptors.response = [];
+    }
+  }
+};
 
 export default awardFetch;

--- a/packages/award-fetch/src/utils/fetch.ts
+++ b/packages/award-fetch/src/utils/fetch.ts
@@ -111,13 +111,19 @@ function mergeOptions(_options: IOpt1, defaultOpt?: IOptdefault): IOpt2 {
  * web client fetch
  * @param  {[object]} options fetch参数
  */
-export default (options: IOpt1) => {
+export default (options: IOpt1, isInterceptorsResponse: boolean) => {
   const opts: IOpt2 = mergeOptions(options, defaultOptions);
   const { url, params, transformResponse } = opts;
 
   if (needXHR(opts)) {
-    return xhr(opts);
+    return xhr(opts, isInterceptorsResponse);
   }
 
-  return fetch(`${encodeURI(url)}${params}`, opts).then(transformResponse);
+  return fetch(`${encodeURI(url)}${params}`, opts).then(response => {
+    if (isInterceptorsResponse) {
+      return response;
+    } else {
+      return transformResponse(response);
+    }
+  });
 };

--- a/packages/award-fetch/src/utils/log.ts
+++ b/packages/award-fetch/src/utils/log.ts
@@ -1,15 +1,20 @@
+import clientPlugin from 'award-plugin/client';
+
 let customLog: {
   error: Function;
 };
 
 const error = (msg: string | Error, type = '', ...args: string[]) => {
+  if (process.env.RUN_ENV === 'web') {
+    clientPlugin.hooks.catchError({
+      type: 'fetch',
+      error: msg instanceof Error ? msg : new Error(msg)
+    });
+  }
   if (customLog && customLog.error) {
     return customLog.error(msg, type, ...args);
   }
-  if (type) {
-    console.error(`[${type}]:`);
-  }
-  console.error(msg);
+  console.error(`${type ? `[${type}]: ` : ''}${msg}`);
 };
 
 export default {

--- a/packages/award-fetch/src/utils/xhr.ts
+++ b/packages/award-fetch/src/utils/xhr.ts
@@ -132,5 +132,5 @@ export function checkStatus(response: Response) {
     return response;
   }
 
-  throw new Error(`${response.url}: ${response.statusText}`);
+  throw { status: 500, message: `${response.url}: ${response.statusText}`, fetch: true };
 }

--- a/packages/award-scripts/src/tools/server/middlewares/hmrEntrySource.ts
+++ b/packages/award-scripts/src/tools/server/middlewares/hmrEntrySource.ts
@@ -40,15 +40,15 @@ export default function hmrEntrySource(this: IServer): Middleware<any, IContext>
     try {
       // 重新加载入口文件
       global.ServerHmr = true;
-      fetch.clean();
       await loadEntryFile.call(self);
       await next();
-      global.ServerHmr = false;
     } finally {
+      fetch.clean();
       if (self.RootPageEntry) {
         removeModule(self.RootPageEntry);
         serverInfo.call(self);
       }
     }
+    global.ServerHmr = false;
   };
 }

--- a/packages/award-scripts/src/tools/server/middlewares/hmrEntrySource.ts
+++ b/packages/award-scripts/src/tools/server/middlewares/hmrEntrySource.ts
@@ -1,13 +1,14 @@
 /**
  * 初始化中间件
  */
-import { clearConsole } from '../../tool';
+import fetch from 'award-fetch';
 import { IContext, IServer, IConfig } from 'award-types';
-import removeModule = require('../../remove');
 import { Middleware } from 'koa';
 import { serverInfo } from 'award-utils/server';
 import nodePlugin from 'award-plugin/node';
 import loadEntryFile from '../utils/loadEntryFile';
+import { clearConsole } from '../../tool';
+import removeModule = require('../../remove');
 
 export default function hmrEntrySource(this: IServer): Middleware<any, IContext> {
   const self = this;
@@ -38,8 +39,11 @@ export default function hmrEntrySource(this: IServer): Middleware<any, IContext>
     }
     try {
       // 重新加载入口文件
+      global.ServerHmr = true;
+      fetch.clean();
       await loadEntryFile.call(self);
       await next();
+      global.ServerHmr = false;
     } finally {
       if (self.RootPageEntry) {
         removeModule(self.RootPageEntry);

--- a/packages/award-scripts/src/tools/server/ws.ts
+++ b/packages/award-scripts/src/tools/server/ws.ts
@@ -34,7 +34,7 @@ export default class WS {
               } else {
                 options.url = `http://localhost:${this.port}${options.url}`;
               }
-              fetch(options).then((data: any) => {
+              fetch(options, options.__file__isInterceptorsResponse).then((data: any) => {
                 wss.send(JSON.stringify(data));
               });
             }

--- a/packages/award-server/src/middleware/basic/init.ts
+++ b/packages/award-server/src/middleware/basic/init.ts
@@ -73,7 +73,7 @@ export default function(this: IServer, version: string): Middleware<any, IContex
        * 错误处理, 优先接收 err.status, 比如处理404
        */
       ctx.status = err.status || 500;
-      self.ErrorCatchFunction(contextLog(err, 'node'));
+      self.ErrorCatchFunction(contextLog(err, 'node'), ctx);
       if (self.dev && !self.ignore) {
         // 如果没有设置忽略，将展示系统默认错误页面
         throw err;
@@ -111,7 +111,7 @@ export default function(this: IServer, version: string): Middleware<any, IContex
         try {
           if (ctx.award.routerError) {
             // 渲染错误定位到Layout层面，这个时候渲染全局展示的错误页面
-            self.ErrorCatchFunction(contextLog(newError, 'renderLayout'));
+            self.ErrorCatchFunction(contextLog(newError, 'renderLayout'), ctx);
             // 路由内错误在渲染错误页面时，全局报错，这个时候需要直接渲染错误页面
             ctx.award.routerError = false;
             ctx.body = await pageError(error, ctx, self.renderReactToString);
@@ -122,7 +122,7 @@ export default function(this: IServer, version: string): Middleware<any, IContex
         }
 
         // 错误展示页面确实发生错误了
-        self.ErrorCatchFunction(contextLog(newError, 'renderErrorPage'));
+        self.ErrorCatchFunction(contextLog(newError, 'renderErrorPage'), ctx);
         return finish(newError);
       }
     }

--- a/packages/award-server/src/server/base.ts
+++ b/packages/award-server/src/server/base.ts
@@ -270,9 +270,10 @@ export default class Base {
    * 如果没有将errLogs返回，那么将不会打印错误日志
    *
    * ```
-   * app.catch(errLogs => {
+   * app.catch((errLogs, ctx) => {
    *   // 开发阶段、errLogs为null
    *   // 可以自行处理errLogs，决定是否将错误errLogs发送到终端，即打印日志
+   *   // ctx表示当前发生错误的请求的上下文对象
    *   return newErrLogs;
    * })
    * ```
@@ -289,9 +290,9 @@ export default class Base {
 
   private handleError(cb: Function) {
     if (typeof cb === 'function') {
-      this.ErrorCatchFunction = (errLogs: any) => {
+      this.ErrorCatchFunction = (errLogs: any, ctx: IContext) => {
         // 触发回调catch处理当前错误日志
-        const info = cb(errLogs);
+        const info = cb(errLogs, ctx);
         if (info && _.isObject(info)) {
           // 向终端打印日志
           console.error(JSON.stringify(info));

--- a/packages/award/server.d.ts
+++ b/packages/award/server.d.ts
@@ -87,15 +87,16 @@ declare module 'award/server' {
      * 如果没有将errLogs返回，那么将不会打印错误日志
      *
      * ```
-     * app.catch(errLogs => {
+     * app.catch((errLogs, ctx) => {
      *   // 开发阶段、errLogs为null
      *   // 可以自行处理errLogs，决定是否将错误errLogs发送到终端，即打印日志
+     *   // ctx表示当前发生错误的请求的上下文对象
      *   return newErrLogs;
      * })
      * ```
      *
      */
-    catch(cb: Function): void;
+    catch(cb: (error: object, ctx: IContext) => object): void;
 
     /**
      *

--- a/website/readme.md
+++ b/website/readme.md
@@ -1,0 +1,17 @@
+## 开发
+
+```shell
+$ npm run dev
+```
+
+## 发布
+
+```shell
+# 编译
+$ npm run build
+
+# 拷贝
+$ rsync -av build/award-docs/* ../../gh-pages
+```
+
+[rsync下载安装地址](https://rsync.samba.org/)

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -38,6 +38,8 @@ const siteConfig = {
   blogSidebarCount: 'ALL',
   blogSidebarTitle: { default: '最近博客', all: '全部博客' },
 
+  // https://docsearch.algolia.com/apply/
+
   algolia: {
     apiKey: '7d689b8feb15c55f80f2cb5cf393d503',
     indexName: 'ximalaya_award'


### PR DESCRIPTION
## 请求劫持处理
 > 全局生效
 
```js
import fetch from "award-fetch";

// request 表示请求参数
// log是函数，可以在服务器输出错误 log.error
fetch.interceptors.request.use((request, log) => {
   console.log(request);
   return request
});
 
// 响应劫持处理
// response 表示请求参数
// log是函数，可以在服务器输出错误 log.error
fetch.interceptors.response.use((response, log) => {
   console.log(response);
   // 如果这里判断响应码不对，可以通过log.error打印错误
   // 那么打印的错误会进入pm2日志记录下来
   return response.json();
});
```

## app.catch
> 现在node端award框架内部抛出的错误都标准化了
>
> app.catch支持传入上下文参数ctx

```
app.catch((errLogs,ctx)=>{
  console.log("path",ctx.path);
  return errLogs
})
```

**[具体请点击参考文档](https://ximalayacloud.github.io/award/docs/basic/server#%E7%BB%88%E6%9E%81%E9%94%99%E8%AF%AF%E6%8D%95%E8%8E%B7%E5%8F%8A%E8%87%AA%E5%AE%9A%E4%B9%89%E5%A4%84%E7%90%86)**
