### PR TITLE
重新调整award-fetch的response截取逻辑

### DIFF
--- a/__tests__/fetch/node.award.spec.ts
+++ b/__tests__/fetch/node.award.spec.ts
@@ -165,4 +165,18 @@ describe('测试award-fetch  node', () => {
       });
     });
   });
+
+  it('错误请求未知尝试', async () => {
+    const fetch = require('award-fetch').default;
+    await new Promise(resolve => {
+      fetch('http://a.b.c.com/a', {
+        method: 'POST'
+      }).catch((e: any) => {
+        expect(e.message).toBe(
+          'request to http://a.b.c.com/a failed, reason: getaddrinfo ENOTFOUND a.b.c.com'
+        );
+        resolve();
+      });
+    });
+  });
 });

--- a/__tests__/fetch/node.award.spec.ts
+++ b/__tests__/fetch/node.award.spec.ts
@@ -158,8 +158,8 @@ describe('测试award-fetch  node', () => {
       fetch(server.url, {
         method: 'POST',
         dataType: 'text'
-      }).catch((err: any) => {
-        expect(err.message).toBe(`${server.url}: Internal Server Error`);
+      }).then((response: any) => {
+        expect(response.ok).toBeFalsy();
         expect(retry).toHaveBeenCalledTimes(3);
         resolve();
       });

--- a/__tests__/fetch/web.spec.ts
+++ b/__tests__/fetch/web.spec.ts
@@ -43,15 +43,16 @@ describe('测试award-fetch web', () => {
       return req;
     });
 
-    fetch.interceptors.response.use((res: any) => {
-      return new Promise(async resolve => {
-        const data = await res.text();
+    fetch.interceptors.response.use(async (data: any, res: any) => {
+      return await new Promise(async resolve => {
+        expect(res.ok).toBeTruthy();
         resolve(data + ' world');
       });
     });
 
     const info = jest.fn();
-    fetch.interceptors.response.use(() => {
+    fetch.interceptors.response.use((data: any) => {
+      expect(data).toBe('hello world');
       info();
     });
 

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -8,8 +8,8 @@ import './app.scss';
 
 fetch.interceptors.response.use((response, log) => {
   log.error('发生错误了', 'interceptors response');
-  console.error(1234, response.status);
-  return response.json();
+  console.error(1234, response);
+  return response;
 });
 
 function app(props) {
@@ -56,12 +56,7 @@ function app(props) {
 
 app.getInitialProps = ctx => {
   const result = [
-    fetch('/api/list', {
-      transformResponse: response => {
-        console.log(321, response);
-        return response;
-      }
-    }).then(data => {
+    fetch('/api/list').then(data => {
       ctx.setAward({
         num: data.num
       });

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -8,7 +8,8 @@ import './app.scss';
 
 fetch.interceptors.response.use((data, response, log) => {
   log.error('发生错误了', 'interceptors response');
-  console.error('[response.status] ', response.status);
+  console.log('[response data]:', data);
+  console.error('[response.status]', response.status);
   return data;
 });
 

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -60,7 +60,7 @@ function app(props) {
 
 app.getInitialProps = ctx => {
   const result = [
-    fetch('http://a.com/api/error')
+    fetch('/api/list')
       .then(async data => {
         console.log(1, data);
         // const t = await data.text();

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -6,7 +6,7 @@ import About from './about';
 import './common.scss!';
 import './app.scss';
 
-fetch.interceptors.response.use((response, data, log) => {
+fetch.interceptors.response.use((data, response, log) => {
   log.error('发生错误了', 'interceptors response');
   console.error('[response.status] ', response.status);
   return data;

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { start, Consumer, basename } from 'award';
+import { start, Consumer, basename, Head } from 'award';
 import fetch from 'award-fetch';
 import Home from './home';
 import About from './about';
@@ -8,7 +8,7 @@ import './app.scss';
 
 fetch.interceptors.response.use((response, data, log) => {
   log.error('发生错误了', 'interceptors response');
-  console.error(1234, response);
+  console.error('[response.status] ', response.status);
   return data;
 });
 
@@ -21,6 +21,9 @@ function app(props) {
   }
   return (
     <>
+      <Head>
+        <title>basic</title>
+      </Head>
       <p>basename：{basename()}</p>
       <h1
         onClick={() => {

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -8,7 +8,7 @@ import './app.scss';
 
 fetch.interceptors.response.use((data, response, log) => {
   log.error('发生错误了', 'interceptors response');
-  console.log('[response data]:', data);
+  console.log('[response data]:', data.ok);
   console.error('[response.status]', response.status);
   return data;
 });
@@ -60,11 +60,18 @@ function app(props) {
 
 app.getInitialProps = ctx => {
   const result = [
-    fetch('/api/list').then(data => {
-      ctx.setAward({
-        num: data.num
-      });
-    })
+    fetch('http://a.com/api/error')
+      .then(async data => {
+        console.log(1, data);
+        // const t = await data.text();
+        // console.log('res', data.ok, t);
+        ctx.setAward({
+          num: data.num
+        });
+      })
+      .catch(e => {
+        console.log(e);
+      })
   ];
 
   return Promise.all(result);

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -6,10 +6,10 @@ import About from './about';
 import './common.scss!';
 import './app.scss';
 
-fetch.interceptors.response.use((response, log) => {
+fetch.interceptors.response.use((response, data, log) => {
   log.error('发生错误了', 'interceptors response');
   console.error(1234, response);
-  return response;
+  return data;
 });
 
 function app(props) {

--- a/examples/basic/server.js
+++ b/examples/basic/server.js
@@ -3,6 +3,15 @@ const Server = require('award/server');
 // 实例化，获取app，构造函数接收对象
 const app = new Server();
 
+app.use(async (ctx, next) => {
+  if (ctx.path == '/api/error') {
+    ctx.status = 500;
+    ctx.body = 'hello';
+    return;
+  }
+  await next();
+});
+
 app.catch((errLogs, ctx) => {
   console.info('ctx', ctx.path);
   return errLogs;

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.21.0-alpha.1",
+  "version": "0.21.0-alpha.2",
   "versions": {
-    "alpha": "0.21.0-alpha.1"
+    "alpha": "0.21.0-alpha.2"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.21.0-alpha.2",
+  "version": "0.21.0-alpha.3",
   "versions": {
-    "alpha": "0.21.0-alpha.2"
+    "alpha": "0.21.0-alpha.3"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.21.0-alpha.3",
+  "version": "0.21.0-alpha.4",
   "versions": {
-    "alpha": "0.21.0-alpha.3"
+    "alpha": "0.21.0-alpha.4"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.21.0-alpha.0",
+  "version": "0.21.0-alpha.1",
   "versions": {
-    "alpha": "0.21.0-alpha.0"
+    "alpha": "0.21.0-alpha.1"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.20.0",
+  "version": "0.21.0-alpha.0",
   "versions": {
-    "alpha": "0.20.0-alpha.2"
+    "alpha": "0.21.0-alpha.0"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/packages/award-fetch/src/env/file/index.ts
+++ b/packages/award-fetch/src/env/file/index.ts
@@ -1,9 +1,8 @@
-module.exports = (options: object, isInterceptorsResponse: boolean) => {
+module.exports = (options: object) => {
   return new Promise((resolve, reject) => {
     (function doSocket(win) {
       const _ws = new WebSocket((win as any).AwardWebSocket.url);
       _ws.onopen = () => {
-        (options as any).__file__isInterceptorsResponse = isInterceptorsResponse;
         _ws.send(JSON.stringify(options));
         _ws.onmessage = evt => {
           _ws.close();

--- a/packages/award-fetch/src/env/server/index.ts
+++ b/packages/award-fetch/src/env/server/index.ts
@@ -1,4 +1,4 @@
 import ServerFetch from './server';
-module.exports = (option: any, isInterceptorsResponse: boolean) => {
-  return ServerFetch(option, isInterceptorsResponse);
+module.exports = (option: any) => {
+  return ServerFetch(option);
 };

--- a/packages/award-fetch/src/env/server/server.ts
+++ b/packages/award-fetch/src/env/server/server.ts
@@ -25,11 +25,7 @@ class HttpClient {
     }
   }
 
-  public async startFetch(
-    options: IOpt1,
-    isInterceptorsResponse: boolean,
-    retryTime = this.API_RETRY_TIME
-  ): Promise<any> {
+  public async startFetch(options: IOpt1, retryTime = this.API_RETRY_TIME): Promise<any> {
     const { url } = options;
     try {
       const uri = await this.getUri(url);
@@ -40,33 +36,27 @@ class HttpClient {
           fetch: true
         };
       }
-      const _time1 = Number(new Date());
-      console.info(`[server-fetch-start]:${uri}`);
       try {
-        const data = await fetch(
-          {
-            ...options,
-            url: uri,
-            timeout: this.timeout
-          },
-          isInterceptorsResponse
-        ).then(response => {
-          if (response.status < 200 || response.status > 350) {
-            // 需要重试
-            throw { status: 500, message: `${response.url}: ${response.statusText}`, fetch: true };
+        return await fetch({
+          ...options,
+          url: uri,
+          timeout: this.timeout
+        }).then(response => {
+          if (this.API_RETRY_TIME && retryTime > 0) {
+            // 设置了重试次数，且当前重试次数 > 0
+            if (response.status < 200 || response.status > 350) {
+              throw {
+                message: `${response.url}: ${response.statusText}`
+              };
+            }
           }
           return response;
         });
-        const _time2 = Number(new Date());
-        console.info(`[server-fetch-end]:${uri}(${_time2 - _time1}ms)`);
-        return data;
       } catch (e) {
         if (retryTime > 0) {
-          log.error(uri, 'server-fetch-retry');
-          return this.startFetch(options, isInterceptorsResponse, --retryTime);
+          log.error(e.message, 'server-fetch-retry');
+          return this.startFetch(options, --retryTime);
         }
-        log.error(e.message, 'server-fetch-error');
-        return Promise.reject(e);
       }
     } catch (err) {
       log.error(err, 'apiGetWay-getUri-error');
@@ -88,7 +78,7 @@ class HttpClient {
   }
 }
 
-export default (options: IOpt1, isInterceptorsResponse: boolean) => {
+export default (options: IOpt1) => {
   const { fetch: fetchConfig }: any = getAwardConfig();
   const { timeout = 5000 } = fetchConfig;
   Object.assign(apiGatewayConfig, fetchConfig.apiGateway);
@@ -105,10 +95,7 @@ export default (options: IOpt1, isInterceptorsResponse: boolean) => {
     });
   }
 
-  return httpClient.startFetch(
-    {
-      ...options
-    },
-    isInterceptorsResponse
-  );
+  return httpClient.startFetch({
+    ...options
+  });
 };

--- a/packages/award-fetch/src/env/server/server.ts
+++ b/packages/award-fetch/src/env/server/server.ts
@@ -37,7 +37,7 @@ class HttpClient {
         };
       }
       try {
-        await fetch({
+        return await fetch({
           ...options,
           url: uri,
           timeout: this.timeout

--- a/packages/award-fetch/src/env/thrift/index.ts
+++ b/packages/award-fetch/src/env/thrift/index.ts
@@ -1,6 +1,6 @@
 import thrift from './thrift';
 import { IOptthrift } from '../../interfaces/fetchOptions';
 
-module.exports = (options: IOptthrift, thriftUtils: any, isInterceptorsResponse: boolean) => {
-  return thrift(options, thriftUtils, isInterceptorsResponse);
+module.exports = (options: IOptthrift, thriftUtils: any) => {
+  return thrift(options, thriftUtils);
 };

--- a/packages/award-fetch/src/env/thrift/thrift.ts
+++ b/packages/award-fetch/src/env/thrift/thrift.ts
@@ -48,8 +48,7 @@ export default (
   options: IOptthrift,
   thriftUtils: {
     getClients: Function;
-  },
-  isInterceptorsResponse: boolean
+  }
 ): Promise<any> => {
   const { fetch: fetchConfig = {} }: any = getAwardConfig();
 
@@ -111,7 +110,7 @@ export default (
           const callback = (err: Error, re: any) => {
             if (err) {
               log.error(err, 'fetch-to-thrift-err');
-              fetch(options, isInterceptorsResponse)
+              fetch(options)
                 .then(resolve)
                 .catch(reject);
               thriftClients[thriftKey] = null;
@@ -128,7 +127,7 @@ export default (
         } catch (e) {
           log.error(e, 'thriftPool-connnect-error');
           // thrift连接失败 换http请求
-          fetch(options, isInterceptorsResponse)
+          fetch(options)
             .then(resolve)
             .catch(reject);
           thriftClients[thriftKey] = null;
@@ -136,5 +135,5 @@ export default (
       });
     });
   }
-  return fetch(options, isInterceptorsResponse);
+  return fetch(options);
 };

--- a/packages/award-fetch/src/env/web/index.ts
+++ b/packages/award-fetch/src/env/web/index.ts
@@ -2,7 +2,7 @@ import { loadParams } from 'award-utils';
 import { IOpt1 } from '../../interfaces/fetchOptions';
 import fetch from '../../utils/fetch';
 
-module.exports = (options: IOpt1, isInterceptorsResponse: boolean) => {
+module.exports = (options: IOpt1) => {
   // url
   if (!/^http(s)?:|^\/\//.test(options.url) && (options as any).basename) {
     const { basename } = loadParams.get();
@@ -10,5 +10,5 @@ module.exports = (options: IOpt1, isInterceptorsResponse: boolean) => {
       options.url = basename + (/^\//.test(options.url) ? '' : '/') + options.url;
     }
   }
-  return fetch(options, isInterceptorsResponse);
+  return fetch(options);
 };

--- a/packages/award-fetch/src/index.ts
+++ b/packages/award-fetch/src/index.ts
@@ -18,13 +18,14 @@ const interceptors = {
   },
   response: {
     /**
-     * @response 请求返回的响应对象 Response
      *
      * @data award-fetch处理后的数据结构，比如`json()`、`text()`
      *
+     * @response 请求返回的响应的对象原型 Response
+     *
      * @log 输出日志，log.error
      */
-    use: (func: (response: Response, data: any, log: Log) => Response) => {
+    use: (func: (data: any, response: Response, log: Log) => Response) => {
       _interceptors.response.push(func);
     }
   }
@@ -55,11 +56,12 @@ const interceptors = {
  * })
  *
  * // 响应劫持处理
- * // response 表示请求参数
+ * // data表示award-fetch处理的数据结果
+ * // response 表示响应返回的对象原型
  * // log是函数，可以在服务器输出错误 log.error
- * fetch.interceptors.response.use((response, log) => {
- *  console.log(response);
- *  return response.json();
+ * fetch.interceptors.response.use((data, response, log) => {
+ *  console.log("response status",response.status);
+ *  return data
  * })
  * ```
  *

--- a/packages/award-fetch/src/index.ts
+++ b/packages/award-fetch/src/index.ts
@@ -112,51 +112,41 @@ async function awardFetch(options: string | IOpt1, otherOptions?: IOptUserBase):
 
   (options as any).basename = awardFetch.basename;
 
-  const isInterceptorsResponse = Boolean(_interceptors.response.length);
-
   // 环境判断
   if (process.env.RUN_ENV === 'node') {
     const { thrift } = options;
     if (thrift) {
-      response = require('./env/thrift')(options, thriftUtils, isInterceptorsResponse);
+      response = require('./env/thrift')(options, thriftUtils);
     } else {
-      response = require('./env/server')(options, isInterceptorsResponse);
+      response = require('./env/server')(options);
     }
   } else if (process.env.WEB_TYPE === 'WEB_SPA') {
     // 单页应用开发环境
     if (Number(process.env.Browser) === 1) {
       // 这里走websocket
-      response = require('./env/file')(options, isInterceptorsResponse);
+      response = require('./env/file')(options);
     } else {
       // 这里是web端
-      response = require('./env/web')(options, isInterceptorsResponse);
+      response = require('./env/web')(options);
     }
   } else {
     // 这里是在线的web端
-    response = require('./env/web')(options, isInterceptorsResponse);
+    response = require('./env/web')(options);
   }
-  return response
-    .then((data: any) => {
-      return reduce(
-        _interceptors.response,
-        (res, interceptor) => {
-          const result = interceptor(res, log);
-          if (result) {
-            return result;
-          } else {
-            return res;
-          }
-        },
-        data
-      );
-    })
-    .then((data: any) => {
-      if (isInterceptorsResponse && typeof (options as any).transformResponse === 'function') {
-        return (options as any).transformResponse(data);
-      } else {
-        return data;
-      }
-    });
+  return response.then((data: any) => {
+    return reduce(
+      _interceptors.response,
+      (res, interceptor) => {
+        const result = interceptor(res, log);
+        if (result) {
+          return result;
+        } else {
+          return res;
+        }
+      },
+      data
+    );
+  });
 }
 
 function all(fetches: any) {

--- a/packages/award-fetch/src/index.ts
+++ b/packages/award-fetch/src/index.ts
@@ -18,6 +18,7 @@ const interceptors = {
   },
   response: {
     /**
+     * 回调函数支持 async await
      *
      * @data award-fetch处理后的数据结构，比如`json()`、`text()`
      *

--- a/packages/award-fetch/src/utils/fetch.ts
+++ b/packages/award-fetch/src/utils/fetch.ts
@@ -125,7 +125,7 @@ export default (options: IOpt1) => {
     return reduce(
       interceptors.response,
       (transformData, interceptor) => {
-        const result = interceptor(response, transformData, log);
+        const result = interceptor(transformData, response, log);
         if (result) {
           return result;
         } else {

--- a/packages/award-fetch/src/utils/interceptors.ts
+++ b/packages/award-fetch/src/utils/interceptors.ts
@@ -1,0 +1,16 @@
+export const interceptors: {
+  request: Function[];
+  response: Function[];
+} = {
+  request: [],
+  response: []
+};
+
+export const clean = () => {
+  if (process.env.NODE_ENV === 'development') {
+    if (global.ServerHmr) {
+      interceptors.request = [];
+      interceptors.response = [];
+    }
+  }
+};

--- a/packages/award-fetch/src/utils/xhr.ts
+++ b/packages/award-fetch/src/utils/xhr.ts
@@ -7,7 +7,7 @@ import isFunction = require('lodash/isFunction');
 import { IOpt2 } from '../interfaces/fetchOptions';
 import { COMMONERROR, ABORTERROR } from './constant';
 
-export default function request(options: IOpt2, isInterceptorsResponse: boolean): Promise<any> {
+export default function request(options: IOpt2): Promise<any> {
   return new Promise((resolve: (rdata: any) => void, reject: (reason: any) => void) => {
     const {
       method,
@@ -40,30 +40,21 @@ export default function request(options: IOpt2, isInterceptorsResponse: boolean)
         return;
       }
 
-      if (isInterceptorsResponse) {
-        const responseData =
-          !dataType || dataType === 'string' || dataType === 'text'
-            ? xhr.responseText
-            : xhr.response;
-        resolve(responseData);
-      } else {
-        try {
-          checkStatus({
-            url,
-            status: xhr.status,
-            statusText: xhr.statusText
-          } as any);
-        } catch (error) {
-          error.award = COMMONERROR;
-          reject(error);
-        }
-
+      try {
+        checkStatus({
+          url,
+          status: xhr.status,
+          statusText: xhr.statusText
+        } as any);
         const responseData =
           !dataType || dataType === 'string' || dataType === 'text'
             ? xhr.responseText
             : transformResponse(xhr.response);
 
         resolve(responseData);
+      } catch (error) {
+        error.award = COMMONERROR;
+        reject(error);
       }
 
       xhr = null;
@@ -132,5 +123,5 @@ export function checkStatus(response: Response) {
     return response;
   }
 
-  throw { status: 500, message: `${response.url}: ${response.statusText}`, fetch: true };
+  throw { status: 500, message: `${response.url}: ${response.statusText}`, fetch: true, response };
 }

--- a/packages/award-render/src/html/index.tsx
+++ b/packages/award-render/src/html/index.tsx
@@ -180,7 +180,15 @@ export default async (
   }
 
   // 直出html页面
-  const finalHtml = '<!DOCTYPE html>' + renderToString(<DocumentComponent {...myDoc} {...data} />);
+  const finalHtml =
+    '<!DOCTYPE html>' +
+    renderToString(
+      <>
+        <>
+          <DocumentComponent {...myDoc} {...data} />
+        </>
+      </>
+    );
 
   // 触发渲染后钩子
   await nodePlugin.hooks.afterRender({ context: ctx, html: finalHtml });

--- a/packages/award-render/src/html/structure.tsx
+++ b/packages/award-render/src/html/structure.tsx
@@ -7,6 +7,8 @@ import { IContext } from 'award-types';
 import { getBundles } from 'react-loadable/webpack';
 import * as path from 'path';
 
+require('react-helmet/lib/HelmetConstants.js').HELMET_ATTRIBUTE = '';
+
 const styleModulefile = path.join(process.cwd(), 'node_modules/.cache/award/.moduleStyles.json');
 
 const createStyleLink = (ctx: IContext) => {

--- a/packages/award-server/src/middleware/basic/init.ts
+++ b/packages/award-server/src/middleware/basic/init.ts
@@ -18,7 +18,6 @@ export default function(this: IServer, version: string): Middleware<any, IContex
 
       if (url === '/healthcheck') {
         // 健康检查
-        console.info(`${new Date()}: ___healthcheck`);
         ctx.body = 'healthCheck success';
       } else if (url === '/favicon.ico') {
         ctx.status = 200;

--- a/packages/award-server/src/middleware/kernel/cache/load.ts
+++ b/packages/award-server/src/middleware/kernel/cache/load.ts
@@ -38,14 +38,18 @@ const cacheUtil = {
     // 路径匹配缓存在
     if (html) {
       // 直接读缓存，不做任何计算处理
-      console.info(`[hit]${path}`);
+      if (process.env.NODE_ENV !== 'production') {
+        console.info(`[hit]${path}`);
+      }
       ctx.set('X-Award-Cache', 'true');
     }
     return html;
   },
   set(ctx: IContext, html: string) {
     const path = this._getPath(ctx);
-    console.info(`[cache]: ${path}`);
+    if (process.env.NODE_ENV !== 'production') {
+      console.info(`[cache]: ${path}`);
+    }
     if (path) {
       pageCache.set(path, html);
     }

--- a/packages/award-server/src/utils/page_error.ts
+++ b/packages/award-server/src/utils/page_error.ts
@@ -14,7 +14,9 @@ export default async function PageError(
 
   if (url != null) {
     // 抛出重定向
-    console.info('[redirect]', url);
+    if (process.env.NODE_ENV !== 'production') {
+      console.info('[redirect]', url);
+    }
     ctx.status = status === 301 ? status : 302;
     if (!/^http(s)?:/.test(url)) {
       ctx.redirect(ctx.award.config.basename + url);

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -39,10 +39,9 @@ const siteConfig = {
   blogSidebarTitle: { default: '最近博客', all: '全部博客' },
 
   // https://docsearch.algolia.com/apply/
-
   algolia: {
-    apiKey: '7d689b8feb15c55f80f2cb5cf393d503',
-    indexName: 'ximalaya_award'
+    apiKey: 'ec1057b369ccdb82237f71eced4babef',
+    indexName: 'ximalayacloud_award'
   },
 
   /* path to images for header/footer */


### PR DESCRIPTION
## 请求劫持处理
 > 全局生效

```js
// 响应劫持处理
// data award-fetch内处理的数据返回
// response 表示响应返回的原型对象
// log是函数，可以在服务器输出错误 log.error
fetch.interceptors.response.use((data, response, log) => {
   console.log(response.status,response.ok);
   // 如果这里判断响应码不对，可以通过log.error打印错误
   // 那么打印的错误会进入pm2日志记录下来
   return data;
});
```
