### PR TITLE
移除mock的bodyParse

### DIFF
--- a/packages/award-scripts/src/tools/server/middlewares/mock.ts
+++ b/packages/award-scripts/src/tools/server/middlewares/mock.ts
@@ -31,31 +31,6 @@ function error(ctx: Context, err: Err) {
   });
 }
 
-// parse request body
-const bodyParser = (ctx: Context) => {
-  const chunkArr: any[] = [];
-  const { req } = ctx;
-  let bufLen = 0;
-
-  return new Promise(resolve => {
-    req.on('data', chunk => {
-      chunkArr.push(chunk);
-      bufLen += chunk.length;
-    });
-
-    req.on('end', () => {
-      const input = Buffer.concat(chunkArr, bufLen).toString();
-
-      try {
-        (req as any).data = JSON.parse(input);
-      } catch (err) {
-        (req as any).data = input;
-      }
-      resolve();
-    });
-  });
-};
-
 // handler mock file
 const handler = (ctx: IContext, filename: string, urlObj: any) => {
   return new Promise((resolve, reject) => {
@@ -137,7 +112,6 @@ export default function mockMidd() {
       return;
     }
 
-    await bodyParser(ctx);
     try {
       const ret = await handler(ctx, filename, urlObj);
       ctx.type = 'application/json';


### PR DESCRIPTION
```js
// 可以在server.js文件中自己引入koa-body中间件
const Server = require('award/server');
const koaBody = require('koa-body');

const app = new Server({
  ignore: true
});

app.use(
  koaBody({
    multipart: true,
    formidable: {
      maxFileSize: 20000 * 1024 * 1024 // 设置上传文件大小最大限制，默认20M
    }
  })
);

app.listen(1234);

```

```js
// mock的js文件，就可以获取post请求的body
console.log(ctx.request.body)
```

