### PR TITLE
修复路由快速切换生命周期错乱的bug，中间件支持函数式编程

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.10",
   "versions": {
-    "alpha": "1.0.8-alpha.0"
+    "alpha": "1.0.11-alpha.0"
   },
   "hoist": true,
   "npmClient": "yarn",
@@ -12,7 +12,5 @@
     }
   },
   "lerna": "2.11.0",
-  "packages": [
-    "packages/*"
-  ]
+  "packages": ["packages/*"]
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0.11-alpha.1",
+  "version": "1.0.11-alpha.2",
   "versions": {
-    "alpha": "1.0.11-alpha.1"
+    "alpha": "1.0.11-alpha.2"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0.11-alpha.2",
+  "version": "1.0.11-alpha.3",
   "versions": {
-    "alpha": "1.0.11-alpha.2"
+    "alpha": "1.0.11-alpha.3"
   },
   "hoist": true,
   "npmClient": "yarn",

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
-  "version": "1.0.10",
+  "version": "1.0.11-alpha.1",
   "versions": {
-    "alpha": "1.0.11-alpha.0"
+    "alpha": "1.0.11-alpha.1"
   },
   "hoist": true,
   "npmClient": "yarn",
@@ -12,5 +12,7 @@
     }
   },
   "lerna": "2.11.0",
-  "packages": ["packages/*"]
+  "packages": [
+    "packages/*"
+  ]
 }

--- a/packages/award-router/src/RouterSwitch/index.tsx
+++ b/packages/award-router/src/RouterSwitch/index.tsx
@@ -17,7 +17,7 @@ class Router extends React.Component<any, any> {
   public static contextType = AwardRouterContext;
 
   private needUpdateInitialState = true;
-  private renderNum = 0;
+  private renderNum: { [pathname: string]: number } = {};
 
   public constructor(props: any, context: any) {
     super(props, context);
@@ -183,8 +183,8 @@ class Router extends React.Component<any, any> {
     }
 
     // 执行核心路由组件的绘制
-    if (this.renderNum === 0) {
-      this.renderNum = this.state.diffRoutes.length;
+    if (!this.renderNum[this.state.pathname] || this.renderNum[this.state.pathname] <= 0) {
+      this.renderNum[this.state.pathname] = this.state.diffRoutes.length;
     }
     return (
       <SwitchContext.Provider
@@ -229,8 +229,12 @@ class Router extends React.Component<any, any> {
                   fn
                 });
               }
-              this.renderNum--;
-              if (this.renderNum === 0) {
+
+              if (typeof this.renderNum[this.state.pathname] !== 'undefined') {
+                this.renderNum[this.state.pathname]--;
+              }
+
+              if (this.renderNum[this.state.pathname] === 0) {
                 console.log('路由切换渲染以及数据更新完毕');
                 emitter.getEmitter().emit('routerDidUpdate', this.state.award_initialState);
               }

--- a/packages/award-scripts/src/tools/server/middlewares/hmrCoreMiddleware.ts
+++ b/packages/award-scripts/src/tools/server/middlewares/hmrCoreMiddleware.ts
@@ -4,13 +4,23 @@ import { List } from 'immutable';
 import * as _ from 'lodash';
 
 const loadMiddleware = function(this: IServer, middlewares: List<Middleware<any, IContext>>) {
-  const { app } = this.config.toObject() as IConfig;
+  const config = this.config.toObject() as IConfig;
+  const { app } = config;
   let _middlewares = middlewares.toArray();
   const result: any = app(_middlewares);
   if (result && _.isArray(result)) {
     _middlewares = result;
   }
-  return _middlewares;
+  const resMiddlewares: any[] = [];
+  _middlewares.forEach(item => {
+    // 如果是数组，传入config和app，供调用运行，并返回中间件函数
+    if (Array.isArray(item)) {
+      resMiddlewares.push((item as any)[0](this.app, config));
+    } else {
+      resMiddlewares.push(item);
+    }
+  });
+  return resMiddlewares;
 };
 
 export default function hmrCoreMiddleware(

--- a/packages/award-server/src/server/index.ts
+++ b/packages/award-server/src/server/index.ts
@@ -244,13 +244,11 @@ export class Server extends Base {
         this.coreMiddlewares = result;
       }
       this.coreMiddlewares.forEach(item => {
-        // 直接是async函数，那就直接插入中间件
-        if (item.constructor.name === 'AsyncFunction') {
+        // 如果是数组，传入config和app，供调用运行，并返回中间件函数
+        if (Array.isArray(item)) {
+          this.middlewares.push((item as any)[0](this.app, config));
+        } else {
           this.middlewares.push(item);
-        }
-        // 如果是普通函数，传入config和app，供调用运行，并返回async的中间件函数
-        if (item.constructor.name === 'Function') {
-          this.middlewares.push((item as any)(this.app, config));
         }
       });
     }

--- a/scripts/eslint/index.js
+++ b/scripts/eslint/index.js
@@ -68,7 +68,7 @@ function runESLint() {
   if (package) {
     console.log(chalk.green(`🏖  Linting ${package} files...`));
   } else {
-    console.log(chalk.green(`🏖  Linting all files...`));
+    console.log(chalk.green(`🏖  Linting ${onlyChanged ? 'changed' : 'all'} files...`));
   }
 
   const { errorCount, warningCount, output } = runESLintOnFilesWithOptions(allPaths, onlyChanged);


### PR DESCRIPTION
# award.config.js

```js

// 函数式的中间件，必须使用数组进行包裹，格式如下
const middleware = [(app, config)=>{
   // app表示当前koa的实例
   // config则是当前award.config.js的配置信息，可以extends
   // 必须返回中间件
   return async(ctx,next)=>{
      await next();
   }
}]

export default {
   app: (middlewares) => {
     middlewares.splice(0, 0, middleware);
   }
}
```