### PR TITLE
添加award-fetch 开启API_APIGATEWAY_OPEN情况下 对完整http url的兼容

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 # CHANGELOG to Award
 
+hello

--- a/packages/award-fetch/src/env/server/server.ts
+++ b/packages/award-fetch/src/env/server/server.ts
@@ -73,6 +73,10 @@ class HttpClient {
     }
   }
   private async getApiGatewayUri(url: string) {
+    // 如 是http开头，直接返回url
+    if (/^http(s)?:/.test(url)) {
+      return url;
+    }
     const apiGatewayServerIP = await instance.getApiServer();
     return `http://${apiGatewayServerIP}${url}`;
   }


### PR DESCRIPTION
场景：
nodeJs 服务端需调用来自多后端服务的api，

且有些api 可以使用API_APIGATEWAY_OPEN开启后 返回的ip访问

有些api 需要使用http 直接访问